### PR TITLE
fix the getShardedRegsteredTests' count bug.

### DIFF
--- a/doctest/doctest.h
+++ b/doctest/doctest.h
@@ -4004,6 +4004,9 @@ namespace detail {
     std::vector<const TestCase*> getShardedRegsteredTests(uint32_t cpu_num, uint32_t shard) {
         auto& total_cases = getRegisteredTests();
         auto num_per_shard = uint32_t(total_cases.size() / cpu_num);
+        if (total_cases.size() % cpu_num != 0) {
+            num_per_shard++;
+        }
         // but the start_offset and end_offset was just an assumption of normail size of TestCase.
         auto start_offset = num_per_shard * shard;
         auto end_offset =  num_per_shard * (shard+1);

--- a/doctest/parts/doctest.cpp
+++ b/doctest/parts/doctest.cpp
@@ -1190,6 +1190,9 @@ namespace detail {
     std::vector<const TestCase*> getShardedRegsteredTests(uint32_t cpu_num, uint32_t shard) {
         auto& total_cases = getRegisteredTests();
         auto num_per_shard = uint32_t(total_cases.size() / cpu_num);
+        if (total_cases.size() % cpu_num != 0) {
+            num_per_shard++;
+        }
         // but the start_offset and end_offset was just an assumption of normail size of TestCase.
         auto start_offset = num_per_shard * shard;
         auto end_offset =  num_per_shard * (shard+1);


### PR DESCRIPTION
make doctests framework will not skip the last testcases.